### PR TITLE
Improve CI rules

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,9 +59,9 @@ jobs:
         name: test-firmware-${{ matrix.board }}
         path: |
           .pio/build/**/*.hex
-          # .pio/build/**/*.bin # Dont think this is required for any boards, and makes filesize incorrect?!.
+          # .pio/build/**/*.bin # Should not be required for any boards, and makes upload file size incorrect!
           .pio/build/**/*.elf
-          .pio/build/**/*.map
+          # .pio/build/**/*.map # Currently not generated.
 
     - if: github.event_name == 'push' && github.ref == 'refs/heads/master' #TODO handle previews
       name: Create Release
@@ -73,7 +73,7 @@ jobs:
         draft: false
         prerelease: false
 
-    - if: github.event_name == 'push' && github.ref == 'refs/heads/master' #TODO handle previews
+    - if: github.event_name == 'push' && github.ref == 'refs/heads/master' && ${{ matrix.board != 'template' }} #TODO handle previews
       name: Upload binary for release
       id: upload-release-asset 
       uses: actions/upload-release-asset@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
         platformio run -e ${{ matrix.board }}
         # platformio system prune --force
 
-    - if: ${{ matrix.board != 'template' }}
+    - if: matrix.board != 'template'
       name: Upload firmware artifact to current run
       uses: actions/upload-artifact@v2
       with:
@@ -73,7 +73,7 @@ jobs:
         draft: false
         prerelease: false
 
-    - if: github.event_name == 'push' && github.ref == 'refs/heads/master' && ${{ matrix.board != 'template' }} #TODO handle previews
+    - if: github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.board != 'template' #TODO handle previews
       name: Upload binary for release
       id: upload-release-asset 
       uses: actions/upload-release-asset@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,14 +52,14 @@ jobs:
         platformio run -e ${{ matrix.board }}
         # platformio system prune --force
 
-    - if: ${{ matrix.board }} != 'template'
+    - if: ${{ matrix.board != 'template' }}
       name: Upload firmware artifact to current run
       uses: actions/upload-artifact@v2
       with:
         name: test-firmware-${{ matrix.board }}
         path: |
           .pio/build/**/*.hex
-          # .pio/build/**/*.bin
+          # .pio/build/**/*.bin # Dont think this is required for any boards, and makes filesize incorrect?!.
           .pio/build/**/*.elf
           .pio/build/**/*.map
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,13 +52,14 @@ jobs:
         platformio run -e ${{ matrix.board }}
         # platformio system prune --force
 
-    - name: Upload firmware artifact to current run
+    - if: ${{ matrix.board }} != 'template'
+      name: Upload firmware artifact to current run
       uses: actions/upload-artifact@v2
       with:
         name: test-firmware-${{ matrix.board }}
         path: |
           .pio/build/**/*.hex
-          .pio/build/**/*.bin
+          # .pio/build/**/*.bin
           .pio/build/**/*.elf
           .pio/build/**/*.map
 


### PR DESCRIPTION
* Adds STM32F7 builds
* Stops template upload (waste of storage)
* Removes `.bin` and `.map` upload as un-required (and `.bin` reports as an unusually large file on github!).